### PR TITLE
Update code of conduct to point to conduct hotline

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ volunteers responsible for responding to CoC concerns. Key information on this
 committee, including the roster and schedule, is available on [CoC On Call
 Roster webpage](http://www.chipy.org/pages/conduct-on-call/).
 
-Reach this committee for CoC Concerns at any time by emailing:
-[chipy.conduct@gmail.com](mailto:chipy.conduct@gmail.com)
+Reach this committee for CoC Concerns at any time via the [ConductHotline
+Report page][https://conducthotline.com/e/chipy] or email the organizers at
+[chicago-organizers@python.org](mailto:chicago-organizers@python.org)
 
 The details of how this Committee operates is available in the [Report Handling
 Procedure](./report-handling-procedure.md).

--- a/boilerplate-short-form.md
+++ b/boilerplate-short-form.md
@@ -9,7 +9,8 @@
 ChiPy is dedicated to creating a welcoming experience for everyone.
 Our code of conduct can be found at: http://www.chipy.org/pages/conduct/
 and you can contact the ChiPy Code of Conduct Committee at the [ConductHotline
-Report page][conduct hotline] or email the organizers at
+Report page][conduct hotline] or email the organizers at 
+chicago-organizers@python.org.
 
 The committee roster is available at [on our website][roster].
 

--- a/boilerplate-short-form.md
+++ b/boilerplate-short-form.md
@@ -8,10 +8,10 @@
 
 ChiPy is dedicated to creating a welcoming experience for everyone.
 Our code of conduct can be found at: http://www.chipy.org/pages/conduct/
-and you can contact the ChiPy Code of Conduct Committee at
-chipy.conduct@gmail.com.
+and you can contact the ChiPy Code of Conduct Committee at the [ConductHotline
+Report page][conduct hotline] or email the organizers at
 
-The committee roster is available at http://www.chipy.org/pages/conduct-on-call/.
+The committee roster is available at [on our website][roster].
 
 ### Medium length (e.g. for brochures and flyers)
 
@@ -53,16 +53,18 @@ Thank you for helping make this a welcoming, friendly environment for all.
 **Contact information:**
 
 If you feel harassed, witness harassment, or have other concerns,
-please contact a member of the ChiPy Code of Conduct Committee
-(chipy.conduct@gmail.com).  If you consider the matter especially
-urgent, please talk to the on call member on duty right away —
-they will be introduced at the beginning of each event.
+please contact a member of [the ChiPy Code of Conduct Committee][roster]
+.  If you consider the matter especially urgent, please talk to the on call
+member on duty right away — they will be introduced at the beginning of each
+event.
 
 Or if you feel uncomfortable speaking in person, you can make an
-anonymous report to chipy.conduct@gmail.com at a time that is
-convenient.
+anonymous report via the [conduct hotline] at a time that is convenient.
 
 A Chipy organizer or representative can help participants contact security
 or local law enforcement, provide escorts, or otherwise assist those
 experiencing harassment to feel safe during the event.
 We value your attendance.
+
+[conduct hotline]: https://conducthotline.com/e/chipy
+[roster]: http://www.chipy.org/pages/conduct-on-call/

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -102,7 +102,7 @@ sponsors should not use sexualised images, activities, or other material.
 Anyone can report harassment. If someone’s behavior has made you uncomfortable,
 or if you have witnessed any form of unacceptable behavior, you should immediately
 contact ChiPy organizers in-person, on Slack, or send an email to the On-Call
-responder at chipy.conduct@gmail.com.
+responder at chicago-organizers@python.com.
 
 Organizers of ChiPy will be happy to help participants contact hotel/venue
 security or local law enforcement, provide escorts, or otherwise assist any

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -102,7 +102,7 @@ sponsors should not use sexualised images, activities, or other material.
 Anyone can report harassment. If someone’s behavior has made you uncomfortable,
 or if you have witnessed any form of unacceptable behavior, you should immediately
 contact ChiPy organizers in-person, on Slack, or send an email to the On-Call
-responder at chicago-organizers@python.com.
+responder at chicago-organizers@python.org.
 
 Organizers of ChiPy will be happy to help participants contact hotel/venue
 security or local law enforcement, provide escorts, or otherwise assist any

--- a/incident-response.md
+++ b/incident-response.md
@@ -14,7 +14,7 @@ individual consideration on a case-to-case basis.
 The intent of incident response is to provide a guideline for how to
 respond to Code of Conduct issues while they are happening.
 Regardless of the severity of the incident, a report should be
-sent to chipy.conduct@gmail.com as soon as is convenient.
+sent via [conduct hotline] as soon as is convenient.
 
 1. If there is immediate danger or you are unsure, contact
    security or local law enforcement.
@@ -47,7 +47,7 @@ Do not pressure the reporter to take any action if they do not want to do it.
 Respect the reporter's privacy by not sharing unnecessary details with others,
 especially individuals who were not involved with the situation or non-staff members.
 
-Reports should be sent to chipy.conduct@gmail.com as soon as practical.
+Reports should be sent to the [conduct hotline] as soon as practical.
 The report should include as much of the following as you can remember:
 - Identifying information (name/badge number) of the participant
 - The time the incident was reported
@@ -61,7 +61,7 @@ The report should include as much of the following as you can remember:
 
 Any member of the Chipy Code of Conduct Committee can issue a verbal warning
 to a participant that their behavior violates ChiPy’s code of conduct.
-Warnings should be logged via an email to to chipy.conduct@gmail.com as
+Warnings should be logged via an email to the [conduct hotline] as
 soon as practical.
 The report should include as much of the following as you can remember:
 
@@ -82,3 +82,5 @@ should take immediate action to politely and calmly stop any
 presentation or event that repeatedly or seriously violates the
 Code of Conduct.  For example, simply say *"I'm sorry, this presentation
 cannot be continued at the present time"* with no further explanation.
+
+[conduct hotline]: https://conducthotline.com/e/chipy

--- a/report-handling-procedure.md
+++ b/report-handling-procedure.md
@@ -11,8 +11,8 @@ individual consideration on a case-to-case basis.
 
 ### How we receive reports
 
-All reports sent to the [chipy.conduct@gmail.com](mailto:chipy.conduct@gmail.com)
-email address are automatically forwarded to the on-call receivers of complaints.
+All reports sent to the [conduct hotline] email address are automatically
+forwarded to the on-call receivers of complaints.
 
 It is possible for a member to receive a report individually via email, Slack or
 in-person. The member will be responsible for compiling an incident report and
@@ -36,7 +36,7 @@ month long on-call duty that is rotated between members of the Conduct
 Committee. On the first meeting of each month, we assign one member to be the
 primary person on duty and another member to be a secondary supporter. The
 committee roster and the schedule is managed via [On Call
-Roster](http://www.chipy.org/pages/conduct-on-call/).
+Roster][roster].
 
 **Primary person on duty** is responsible for providing the initial response to
  a reporter, ideally within half a day. They're also responsible for either
@@ -213,3 +213,6 @@ This guide was borrowed almost-entirely from the excellent Django Code of
 Conduct [Report Handling
 Procedure](https://github.com/django/code-of-conduct/blob/master/reports.md).
 We remain extemely grateful for their thorough, transparent example.
+
+[conduct hotline]: https://conducthotline.com/e/chipy
+[roster]: http://www.chipy.org/pages/conduct-on-call/


### PR DESCRIPTION
The Board voted to adopt ConductHotline as our official reporting
mechanism. This commit updates our code of conduct in compliance with
that decision.